### PR TITLE
SVG For Colonel Kurtz

### DIFF
--- a/app/assets/javascripts/admin/colonel/blockTypes/Icon.js
+++ b/app/assets/javascripts/admin/colonel/blockTypes/Icon.js
@@ -1,0 +1,41 @@
+var React = require('react')
+var Select = require('./Select')
+
+module.exports = React.createClass({
+
+  getDefaultProps() {
+    return {
+      content: { id: '' }
+    }
+  },
+
+  render: function() {
+    return (
+      <div>
+        <p className="col-block__label">Icon</p>
+        <Select
+          onChange={ this.onChange }
+          items={ AVAILABLE_ICONS.map(this.toItem) }
+          selected={ this.props.content.id }
+          message={ 'Select an Icon' }
+          renderOption={ this.renderOption }
+        />
+      </div>
+    )
+  },
+
+  onChange: function(id) {
+    this.props.onChange({ id })
+  },
+
+  toItem: function(filepath) {
+    var array = filepath.split('/')
+    var filename = array[array.length-1].replace(/[\.].+$/, '').replace('_', ' ')
+    var label = filename.charAt(0).toUpperCase() + filename.slice(1)
+    return { filepath, label }
+  },
+
+  renderOption: function(item) {
+    return <option key={ item.filepath } value={ item.filepath }>{ item.label }</option>
+  }
+})

--- a/app/assets/javascripts/admin/colonel/blockTypes/Select.js
+++ b/app/assets/javascripts/admin/colonel/blockTypes/Select.js
@@ -1,0 +1,52 @@
+var React = require('react')
+
+module.exports = React.createClass({
+  propTypes: {
+    multiple     : React.PropTypes.bool,
+    renderOption : React.PropTypes.func,
+    onChange     : React.PropTypes.func.isRequired,
+    items        : React.PropTypes.array.isRequired,
+    includeBlank : React.PropTypes.bool,
+    selected     : React.PropTypes.oneOfType([
+                     React.PropTypes.array,
+                     React.PropTypes.string
+                   ]),
+    message      : React.PropTypes.string
+  },
+
+  getDefaultProps: function() {
+    return {
+      multiple     : false,
+      includeBlank : true,
+      selected     : '',
+      items        : [],
+      message      : 'Select an option',
+      renderOption : function(item) {
+        return <option key={ item }>{ item }</option>
+      }
+    }
+  },
+
+  renderBlank: function() {
+    if (this.props.includeBlank) {
+      return <option value=''>{ this.props.message }</option>
+    }
+  },
+
+  render: function() {
+    return (
+      <select
+        multiple={ this.props.multiple }
+        value={ this.props.selected }
+        onChange={ this.onChange }
+      >
+        { this.renderBlank() }
+        { this.props.items.map(this.props.renderOption) }
+      </select>
+    )
+  },
+
+  onChange: function(event) {
+    this.props.onChange(event.target.value)
+  }
+})

--- a/app/assets/javascripts/admin/colonel/blockTypes/index.js
+++ b/app/assets/javascripts/admin/colonel/blockTypes/index.js
@@ -9,6 +9,11 @@ module.exports = [
     component:   require('./PhotoPicker')
   },
   {
+    id:         'icon',
+    label:      'Icon',
+    component:  require('./Icon')
+  },
+  {
     id:         'text',
     label:      'Text',
     component:  require('colonel-kurtz/addons/medium')

--- a/app/assets/javascripts/admin/env.js.erb
+++ b/app/assets/javascripts/admin/env.js.erb
@@ -2,3 +2,5 @@
   ADMIN_PHOTOS_PATH          = "<%= urls.admin_photos_path %>"
   ADMIN_NEW_PHOTO_PATH       = "<%= urls.new_admin_photo_path %>"
 <% end %>
+
+AVAILABLE_ICONS = <%= Helpers::DirectoryContentsHelper.get_readable_file_names(directory: '/app/views/shared/icons', filetype: 'html.erb') %>

--- a/app/lib/helpers/directory_contents_helper.rb
+++ b/app/lib/helpers/directory_contents_helper.rb
@@ -2,7 +2,7 @@ module Helpers
 
   class DirectoryContentsHelper
 
-    def self.get_readable_file_names(directory: directory, filetype: filetype)
+    def self.get_readable_file_names(directory:, filetype:)
       Dir.chdir (Rails.root.to_s + directory)
       Dir.glob("*.#{filetype}")
     end

--- a/app/lib/helpers/directory_contents_helper.rb
+++ b/app/lib/helpers/directory_contents_helper.rb
@@ -3,8 +3,10 @@ module Helpers
   class DirectoryContentsHelper
 
     def self.get_readable_file_names(directory:, filetype:)
-      Dir.chdir (Rails.root.to_s + directory)
-      Dir.glob("*.#{filetype}")
+      filenames  = Dir.glob(Rails.root.to_s + directory + "/*.#{filetype}")
+      filenames.map do |file|
+        file.split('/').last
+      end
     end
 
   end

--- a/app/lib/helpers/directory_contents_helper.rb
+++ b/app/lib/helpers/directory_contents_helper.rb
@@ -1,0 +1,12 @@
+module Helpers
+
+  class DirectoryContentsHelper
+
+    def self.get_readable_file_names(directory: directory, filetype: filetype)
+      Dir.chdir (Rails.root.to_s + directory)
+      Dir.glob("*.#{filetype}")
+    end
+
+  end
+
+end

--- a/app/lib/helpers/svg_helper.rb
+++ b/app/lib/helpers/svg_helper.rb
@@ -3,7 +3,7 @@ module Helpers
   class SvgHelper
 
     def self.build_full_filepath(filename)
-      Rails.root.to_s + '/app/views/shared/icons/' + filename
+      Rails.root.join('app', 'views', 'shared', 'icons', filename).to_s
     end
 
   end

--- a/app/lib/helpers/svg_helper.rb
+++ b/app/lib/helpers/svg_helper.rb
@@ -1,0 +1,11 @@
+module Helpers
+
+  class SvgHelper
+
+    def self.build_full_filepath(filename)
+      Rails.root.to_s + '/app/views/shared/icons/' + filename
+    end
+
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,8 +59,8 @@ ActiveRecord::Schema.define(version: 20170727213714) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "position", null: false
     t.string "slug", null: false
+    t.integer "position", null: false
     t.index ["name"], name: "index_devices_on_name", unique: true
   end
 

--- a/spec/lib/directory_contents_helper_spec.rb
+++ b/spec/lib/directory_contents_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Helpers::DirectoryContentsHelper do
+
+  describe '.get_readable_file_names' do
+
+    context 'given an appropriate directory and filetype' do
+
+      it 'correctly returns an array with all files of that filetype in the given directory' do
+        files = Helpers::DirectoryContentsHelper.get_readable_file_names(directory: '/assets/images', filetype: 'jpg')
+
+        expect(files).to include 'device.jpg'
+        expect(files).to include 'roast.jpg'
+      end
+
+    end
+
+  end
+
+end

--- a/spec/lib/svg_helper_spec.rb
+++ b/spec/lib/svg_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Helpers::SvgHelper do
+
+  describe '.build_full_filepath' do
+
+    context 'given a filepath' do
+
+      it 'correctly returns a string corresponding to the appropriate file location' do
+        filepath = Helpers::SvgHelper.build_full_filepath('test.html.erb')
+
+        expect(filepath).to eq (Rails.root.to_s + '/app/views/shared/icons/test.html.erb')
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR adds SVG support for Colonel Kurtz. A custom block is created that expects SVGs to be created as partials, located in the `/app/views/shared/icons` directory, and have a `.html.erb` filetype. 