### PR TITLE
Fix Delete Device/Roast Error

### DIFF
--- a/app/admin/device.rb
+++ b/app/admin/device.rb
@@ -20,7 +20,7 @@ ActiveAdmin.register Device do
     column :actions do |device|
       links = link_to I18n.t('active_admin.view'), resource_path(device)
       links += link_to I18n.t('active_admin.edit'), edit_resource_path(device)
-      if !device.device_problems.any?
+      if device.device_problems.none?
         links += link_to "Delete", resource_path(device), :method => :delete
       end
       links

--- a/app/admin/device.rb
+++ b/app/admin/device.rb
@@ -17,7 +17,14 @@ ActiveAdmin.register Device do
     column "Image" do |device|
       image_tag device.image.thumb('200x200#').url if device.image.present?
     end
-    actions
+    column :actions do |device|
+      links = link_to I18n.t('active_admin.view'), resource_path(device)
+      links += link_to I18n.t('active_admin.edit'), edit_resource_path(device)
+      if !device.device_problems.any?
+        links += link_to "Delete", resource_path(device), :method => :delete
+      end
+      links
+    end
   end
 
   form do |f|

--- a/app/admin/roast.rb
+++ b/app/admin/roast.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Roast do
     column :actions do |roast|
       links = link_to I18n.t('active_admin.view'), resource_path(roast)
       links += link_to I18n.t('active_admin.edit'), edit_resource_path(roast)
-      if !roast.roast_brands.any?
+      if device.device_problems.none?
         links += link_to "Delete", resource_path(roast), :method => :delete
       end
       links

--- a/app/admin/roast.rb
+++ b/app/admin/roast.rb
@@ -22,7 +22,14 @@ ActiveAdmin.register Roast do
     end
     column :description
     column :sub_description
-    actions
+    column :actions do |roast|
+      links = link_to I18n.t('active_admin.view'), resource_path(roast)
+      links += link_to I18n.t('active_admin.edit'), edit_resource_path(roast)
+      if !roast.roast_brands.any?
+        links += link_to "Delete", resource_path(roast), :method => :delete
+      end
+      links
+    end
   end
 
   form do |f|


### PR DESCRIPTION
This PR fixes a bug where a user receives an error when they attempt to delete a Roast or Device when the model has children associated with it. 

To fix the issue, the delete button is simply removed in the CMS if Roast/Device has children associated with it.