### PR TITLE
Remove slack deploy configuration

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,13 +4,6 @@ set :user, "deploy"
 set :default_stage, 'production'
 set :branch, 'master'
 
-# Enable slack notifications about deploy
-set :slack_url,     'https://hooks.slack.com/services/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'
-set :slack_channel, '#intern17-only'
-set :slack_username, 'GroundRules Deploy'
-set :slack_emoji, ':coffee:'
-set :slack_app_url, 'http://www.groundrules.co/'
-
 # Install Node dependencies before precompiling assets
 namespace :deploy do
   namespace :npm do


### PR DESCRIPTION
Slack invalidated this hook because it is exposed publically. While we figure out the best path forward, I've removed the slack configuration.

@yaychris does this make sense? Is there a good way for me to test this locally?